### PR TITLE
Pequeno ajuste das variáveis de ANO e MES na funcao process_sih

### DIFF
--- a/R/process_sih.R
+++ b/R/process_sih.R
@@ -37,12 +37,12 @@ process_sih <- function(data, information_system = "SIH-RD", municipality_data =
 
     # ANO_CMPT
     if("ANO_CMPT" %in% variables_names){
-      data$ANO_CMPT <- as.integer(data$ANO_CMPT)
+      data$ANO_CMPT <- as.integer(as.character(data$ANO_CMPT))
     }
 
     # MES_CMPT
     if("MES_CMPT" %in% variables_names){
-      data$MES_CMPT <- as.integer(data$MES_CMPT)
+      data$MES_CMPT <- as.integer(as.character(data$MES_CMPT))
     }
 
     # ESPEC


### PR DESCRIPTION
Atualmente a função process_sih converte o ANO e MES para um número inteiro, porém como a variável original é um factor, então o número resultante é incorreto.
Eu simplesmente adicionei uma conversão para character antes do integer, com isso o número resultante representa o ANO e MES corretamente.