### PR TITLE
Fix process_sinasc bug RACACOR -- NA

### DIFF
--- a/R/process_sinasc.R
+++ b/R/process_sinasc.R
@@ -337,7 +337,7 @@ process_sinasc <- function(data, municipality_data = TRUE) {
   if ("PESO" %in% variables_names) {
     data <- data %>%
       dplyr::mutate(
-        RACACOR = dplyr::case_match(
+        PESO = dplyr::case_match(
           .data$PESO,
           "0" ~ NA,
           "9999" ~ NA


### PR DESCRIPTION
Fix process_sinasc bug where RACACOR collumn was returning only NAs

- Fixed variable name in PESO processing block (line 340)
- Changed `RACACOR = dplyr::case_match(` to `PESO = dplyr::case_match(`